### PR TITLE
make it impossible to reuse a tokenURI

### DIFF
--- a/contracts/ERC721Tradable.sol
+++ b/contracts/ERC721Tradable.sol
@@ -33,6 +33,7 @@ abstract contract ERC721Tradable is
   uint256 private _currentTokenId = 0;
 
   mapping(uint256 => string) private _tokenURIs;
+  mapping(string => bool) private _tokenURIUsed;
 
   constructor(
     string memory _name,
@@ -61,8 +62,10 @@ abstract contract ERC721Tradable is
       _verifySigner(_owner, _tokenURI, _v, _r, _s),
       'owner should sign tokenURI'
     );
+    require(_tokenURIUsed == false, 'tokenURI already used');
     uint256 newTokenId = _currentTokenId.add(1);
     _tokenURIs[newTokenId] = _tokenURI;
+    _tokenURIUsed[_tokenURI] = true;
     _mint(msg.sender, newTokenId);
     _currentTokenId++;
   }

--- a/contracts/Space.sol
+++ b/contracts/Space.sol
@@ -8,7 +8,10 @@ import './ERC721Tradable.sol';
  * @title Space
  */
 contract Space is ERC721Tradable {
+
   constructor(address _proxyRegistryAddress)
     ERC721Tradable('Space', 'SPACE', _proxyRegistryAddress)
   {}
+
+  
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "ganache-cli": "source .env && ganache-cli -d -p 8545 -i 1337 --gasLimit=10000000 --account=\"0x$ETHEREUM_ACCOUNT_KEY,10000000000000000000000\"",
-    "test": "DEPLOY_ALL=1 truffle test"
+    "test": "DEPLOY_ALL=1 truffle test",
+    "compile": "truffle compile"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This should fix the duplicate NFT problem.  

Note: I didn't test this or even try compiling it.  What it does, is prevent someone from minting a token with a tokenURI that already exists.  This will prevent people from reusing the owner signature to mint duplicate Mona NFTs.  Probably.